### PR TITLE
feat: processor pulls schemas from registry and can validate incoming or outgoing messages against them

### DIFF
--- a/getTopicsAndSchemas.js
+++ b/getTopicsAndSchemas.js
@@ -19,7 +19,7 @@ const registryAuth = {
   password: process.env.REGISTRY_APISECRET,
 };
 
-async function getAndPrintTopicsAndSchemas() {
+async function getTopicsAndSchemas() {
   try {
     const admin = kafka.admin();
     await admin.connect();
@@ -45,4 +45,4 @@ async function getAndPrintTopicsAndSchemas() {
   }
 }
 
-getAndPrintTopicsAndSchemas();
+getTopicsAndSchemas();

--- a/scratchpad.txt
+++ b/scratchpad.txt
@@ -1,0 +1,19 @@
+CREATE TABLE pipelines (
+    id SERIAL PRIMARY KEY,                     -- Unique identifier for the pipeline
+    name VARCHAR(255) NOT NULL UNIQUE,         -- Name of the pipeline, must be unique
+    source_topic_id INT NOT NULL,              -- Foreign key to the source topic
+    target_topic_id INT NOT NULL,              -- Foreign key to the target topic
+    incoming_schema_id INT NOT NULL,           -- Foreign key to the incoming schema
+    outgoing_schema_id INT NOT NULL,           -- Foreign key to the outgoing schema
+    steps JSONB NOT NULL,                      -- JSONB column for steps
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    -- Foreign key constraints with ON DELETE CASCADE
+    CONSTRAINT fk_source_topic FOREIGN KEY (source_topic_id) REFERENCES topics(id),
+    CONSTRAINT fk_target_topic FOREIGN KEY (target_topic_id) REFERENCES topics(id),
+    CONSTRAINT fk_incoming_schema FOREIGN KEY (incoming_schema_id) REFERENCES schemas(id),
+    CONSTRAINT fk_outgoing_schema FOREIGN KEY (outgoing_schema_id) REFERENCES schemas(id)
+);
+
+pg_dump -U postgres -F p your_database > output_file.sql
+
+pg_dump -U postgres --no-owner --no-privileges -F p inflect > inflect_prototype_3.sql


### PR DESCRIPTION
- works with avro, json, and protobuf schemas
- the name for the schemas are passed as arguments to the run function