### PR TITLE
feat: implement pipeline autoscaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ scratchpad.txt
 deployments/pipeline-*-*.yaml
 inflect_prototype_3.sql
 values.yaml
+kafka.properties

--- a/configs/pipeline-deployment-template.yaml
+++ b/configs/pipeline-deployment-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pipeline-{{PIPELINE_ID}}
   namespace: inflect
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: pipeline-{{PIPELINE_ID}}
@@ -69,6 +69,17 @@ spec:
             configMapKeyRef:
               name: kafka-config
               key: registry-url
+        - name: KAFKA_BOOTSTRAP_SERVERS
+          value: "pkc-921jm.us-east-2.aws.confluent.cloud:9092"
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: "SASL_SSL"
+        - name: KAFKA_SASL_MECHANISM
+          value: "PLAIN"
+        - name: KAFKA_SASL_JAAS_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secrets
+              key: sasl-jaas-config
         ports:
         - containerPort: 3000
           name: metrics

--- a/configs/templates/scaledobject-template.yaml
+++ b/configs/templates/scaledobject-template.yaml
@@ -1,0 +1,24 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kafka-scaledobject-{{PIPELINE_ID}}
+  namespace: inflect
+spec:
+  scaleTargetRef:
+    name: pipeline-{{PIPELINE_ID}}
+  pollingInterval: 15
+  cooldownPeriod: 30
+  maxReplicaCount: 10
+  minReplicaCount: 1 
+  triggers:
+  - type: kafka
+    metadata:
+      bootstrapServers: pkc-921jm.us-east-2.aws.confluent.cloud:9092
+      consumerGroup: pipeline-{{PIPELINE_ID}}-source_a-group
+      topic: source_a
+      lagThreshold: "10"
+      offsetResetPolicy: latest
+      allowIdleConsumers: "true"
+      scaleToZeroOnInvalidOffset: "false"
+    authenticationRef:
+      name: kafka-trigger-auth-{{PIPELINE_ID}}

--- a/configs/templates/triggerauthentication-template.yaml
+++ b/configs/templates/triggerauthentication-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: kafka-trigger-auth-{{PIPELINE_ID}}
+  namespace: inflect
+spec:
+  secretTargetRef:
+  - parameter: sasl
+    name: kafka-secrets
+    key: sasl
+  - parameter: username
+    name: kafka-secrets
+    key: apikey
+  - parameter: password
+    name: kafka-secrets
+    key: apisecret
+  - parameter: tls
+    name: kafka-secrets
+    key: tls

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -8,9 +8,31 @@ NAMESPACE="inflect"
 
 echo "Cleaning up resources in namespace $NAMESPACE"
 
+echo "Deleting KEDA ScaledObjects"
+kubectl delete scaledobjects --all -n $NAMESPACE
+
+echo "Deleting KEDA TriggerAuthentications"
+kubectl delete triggerauthentications --all -n $NAMESPACE
+
+echo "Deleting Deployments"
 kubectl delete deployments --all -n $NAMESPACE
+
+echo "Deleting Services"
 kubectl delete services --all -n $NAMESPACE
+
+echo "Deleting PersistentVolumeClaims"
 kubectl delete pvc --all -n $NAMESPACE
+
+echo "Deleting Secrets"
 kubectl delete secrets --all -n $NAMESPACE
+
+echo "Deleting ConfigMaps"
+kubectl delete configmaps --all -n $NAMESPACE
+
+echo "Deleting ServiceMonitors"
+kubectl delete servicemonitors --all -n $NAMESPACE
+
+echo "Deleting HPAs"
+kubectl delete hpa --all -n $NAMESPACE
 
 echo "Cleanup completed."


### PR DESCRIPTION
- Added KEDA deployment to deployment script
- Added KEDA teardown to cleanup script
- Number of pods for each pipeline can scale up or down (current minimum 1 pod, max 10 pods) in response to consumer lag

TODO:
- Add ability to auto-scale number of Kafka partitions for source topics so that the number of partitions matches the number of pods